### PR TITLE
Fixing issue #36. Fixing the string treated as an array bug

### DIFF
--- a/root/etc/cont-init.d/40-inet
+++ b/root/etc/cont-init.d/40-inet
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 network_found=false
-interfaces=$(ip link | awk -F': ' '$0 !~ "lo|wg|tun|tap|^[^0-9]"{print $2;getline}' | cut -d@ -f1)
+interfaces=($(ip link | awk -F': ' '$0 !~ "lo|wg|tun|tap|^[^0-9]"{print $2;getline}' | cut -d@ -f1))
 for iface in "${interfaces[@]}"; do
   inet="$(ip -o addr show dev "${iface}" | awk '$3 == "inet" {print $4}')"
   if [[ -z "$inet" ]]; then

--- a/root/etc/cont-init.d/40-inet6
+++ b/root/etc/cont-init.d/40-inet6
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 network_found=false
-interfaces=$(ip link | awk -F': ' '$0 !~ "lo|wg|tun|tap|^[^0-9]"{print $2;getline}' | cut -d@ -f1)
+interfaces=($(ip link | awk -F': ' '$0 !~ "lo|wg|tun|tap|^[^0-9]"{print $2;getline}' | cut -d@ -f1))
 for iface in "${interfaces[@]}"; do
   inet="$(ip -o addr show dev "${iface}" | awk '$3 == "inet6" {print $4; exit}')"
   if [[ -z "$inet" ]]; then


### PR DESCRIPTION
There is a bug when the container has more than one network interfaces the `etc/cont-init.d/40-inet` rule could not execute successfully. The reason is the command tries to tread a string output as an array.

Tested with following configurations

- with no network interfaces
- with 1 network interfaces
- with 2 network interfaces 

using following docker-compose file

```
version: "3.8"

services:
  vpn:
    image: ghcr.io/bubuntux/nordlynx
    container_name: test-vpn
    networks:
      - network_1
      - network_2
    cap_add:
      - NET_ADMIN
    environment:
      - PRIVATE_KEY=xxxxxxx

networks:
   network_1:
   network_2:
```

