### PR TITLE
docs: update references to nordvpn:get_private_key

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Wireguard module is required, please install it [manually](https://www.wireguard
 
 |                 Variable                 |    Default     | Description |
 |:----------------------------------------:|:--------------:| --- |
-|              `PRIVATE_KEY`               | **[Required]** | The private key can be obtained using `docker run --rm --cap-add=NET_ADMIN -e USER=XXX -e PASS=YYY bubuntux/nordvpn:get_private_key` or following these [instructions](https://forum.openwrt.org/t/instruction-config-nordvpn-wireguard-nordlynx-on-openwrt/89976).
+|              `PRIVATE_KEY`               | **[Required]** | The private key can be obtained using `docker run --rm --cap-add=NET_ADMIN -e TOKEN=XXX bubuntux/nordvpn:get_private_key` with access token or following these [instructions](https://forum.openwrt.org/t/instruction-config-nordvpn-wireguard-nordlynx-on-openwrt/89976).
 |              `PRIVATE_KEY_FILE`          |                | File from which to get PASS, if using docker secrets this should be set to /run/secrets/<secret_name>. This file should contain just the account password on the first line.
 |              `LISTEN_PORT`               |     51820      | A 16-bit port for listening.
 |               `INTERFACE`                |      eth0      | The network interface to use inside the container.

--- a/root/etc/cont-init.d/10-validate
+++ b/root/etc/cont-init.d/10-validate
@@ -14,6 +14,6 @@ if ! iptables -L > /dev/null 2>&1; then
 fi
 
 if [[ -z ${PRIVATE_KEY} ]] && [[ -z ${PRIVATE_KEY_FILE} ]] ; then
-  echo "[$(date -Iseconds)] Missing PRIVATE_KEY, and, PRIVATE_KEY_FILE, try \`docker run --rm --cap-add=NET_ADMIN -e USER=XXX -e PASS=YYY bubuntux/nordvpn:get_private_key\` or follow this instructions https://forum.openwrt.org/t/instruction-config-nordvpn-wireguard-nordlynx-on-openwrt/89976 to obtain the private key."
+  echo "[$(date -Iseconds)] Missing PRIVATE_KEY, and, PRIVATE_KEY_FILE, try \`docker run --rm --cap-add=NET_ADMIN -e TOKEN=XXX bubuntux/nordvpn:get_private_key\` with access token or follow this instructions https://forum.openwrt.org/t/instruction-config-nordvpn-wireguard-nordlynx-on-openwrt/89976 to obtain the private key."
   sleep infinity
 fi


### PR DESCRIPTION
With https://github.com/bubuntux/nordvpn/pull/388 the user+pass option will be succeeded by token input.

However, the image from that change has not been built successfully. This change can't be merged until the image is ready to use.