### PR TITLE
Removes arm32v7 platform. No longer supported by linuxservers.

### DIFF
--- a/.github/workflows/docker-image-ci.yml
+++ b/.github/workflows/docker-image-ci.yml
@@ -48,4 +48,4 @@ jobs:
           context: .
           push: true
           tags: ${{ steps.meta.outputs.tags }}
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
This should fix the failing builds.
linuxserver.io have stated in the past that they were removing support for this platform: https://info.linuxserver.io/issues/2023-07-01-armhf/

Relates to: https://github.com/bubuntux/nordlynx/issues/172