### PR TITLE
Update to Alpine 3.21, enhance Dockerfile, modernise GitHub Actions, 

### DIFF
--- a/.github/workflows/docker-image-ci.yml
+++ b/.github/workflows/docker-image-ci.yml
@@ -26,9 +26,10 @@ jobs:
       - name: Get Tags
         id: meta
         run: |
-          tags="ghcr.io/${{ github.repository }}:edge"
+          tags="ghcr.io/${{ github.repository }}:edge,${{ github.repository }}:edge"
           if [[ $(date '+%d') == 01 || "${{ github.event_name }}" == "push" ]]; then
-            tags="${tags},ghcr.io/${{ github.repository }}:latest,ghcr.io/${{ github.repository }}:$(date '+%Y-%m-%d')"
+            tags="${tags},ghcr.io/${{ github.repository }}:latest,${{ github.repository }}:latest"
+            tags="${tags},ghcr.io/${{ github.repository }}:$(date '+%Y-%m-%d'),${{ github.repository }}:$(date '+%Y-%m-%d')"
           fi
           echo "tags=${tags}" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/docker-image-ci.yml
+++ b/.github/workflows/docker-image-ci.yml
@@ -17,7 +17,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Log into GitHub Container Registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3.4.0
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -26,24 +26,23 @@ jobs:
       - name: Get Tags
         id: meta
         run: |
-          tags="ghcr.io/${{ github.repository }}:edge,${{ github.repository }}:edge"
+          tags="ghcr.io/${{ github.repository }}:edge"
           if [[ $(date '+%d') == 01 || "${{ github.event_name }}" == "push" ]]; then
-            tags="${tags},ghcr.io/${{ github.repository }}:latest,${{ github.repository }}:latest,\
-                  ghcr.io/${{ github.repository }}:$(date '+%Y-%m-%d'),${{ github.repository }}:$(date '+%Y-%m-%d')"
+            tags="${tags},ghcr.io/${{ github.repository }}:latest,ghcr.io/${{ github.repository }}:$(date '+%Y-%m-%d')"
           fi
-          echo "::set-output name=tags::${tags}"
+          echo "tags=${tags}" >> $GITHUB_OUTPUT
 
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v3.6.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3.11.1
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v6.18.0
         with:
           context: .
           push: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,28 @@
-FROM ghcr.io/linuxserver/baseimage-alpine:3.20
+FROM ghcr.io/linuxserver/baseimage-alpine:3.21
 LABEL maintainer="Julio Gutierrez julio.guti+nordlynx@pm.me"
+
+# Set shell options for better error handling
+SHELL ["/bin/ash", "-o", "pipefail", "-c"]
 
 HEALTHCHECK CMD [ $(( $(date -u +%s) - $(wg show wg0 latest-handshakes | awk '{print $2}') )) -le 120 ] || exit 1
 
 COPY /root /
+
+# Set working directory for consistency
+WORKDIR /tmp
+
+# hadolint ignore=DL3003,DL3018
 RUN apk add --no-cache -U iptables ip6tables iptables-legacy wireguard-tools curl jq patch && \
     patch --verbose -d / -p 0 -i /patch/wg-quick.patch && \
     apk del --purge patch && \
     rm -rf /tmp/* /patch && \
-    cd /sbin && \
+    cd /usr/sbin && \
     for i in ! !-save !-restore; do \
-        rm -rf iptables$(echo "${i}" | cut -c2-) && \
-        rm -rf ip6tables$(echo "${i}" | cut -c2-) && \
-        ln -s iptables-legacy$(echo "${i}" | cut -c2-) iptables$(echo "${i}" | cut -c2-) && \
-        ln -s ip6tables-legacy$(echo "${i}" | cut -c2-) ip6tables$(echo "${i}" | cut -c2-); \
+        rm -rf "iptables$(echo "${i}" | cut -c2-)" && \
+        rm -rf "ip6tables$(echo "${i}" | cut -c2-)" && \
+        ln -s "iptables-legacy$(echo "${i}" | cut -c2-)" "iptables$(echo "${i}" | cut -c2-)" && \
+        ln -s "ip6tables-legacy$(echo "${i}" | cut -c2-)" "ip6tables$(echo "${i}" | cut -c2-)" ; \
     done
+
+# Reset to root directory
+WORKDIR /


### PR DESCRIPTION
## 🔄 GitHub Actions Updates
- Update `docker/login-action` from v1 to v3.4.0 
- Update `actions/checkout` to v4
- Update `docker/setup-qemu-action` to v3.6.0
- Update `docker/setup-buildx-action` to v3.11.1  
- Update `docker/build-push-action` to v6.18.0
- Fix deprecated `::set-output` → `$GITHUB_OUTPUT`

## 🐳 Dockerfile Improvements
- Update base image: Alpine 3.20 → 3.21
- Update iptables paths: `/sbin` → `/usr/sbin` (Alpine 3.21 change)
- Add `SHELL` directive with `pipefail` for better error handling
- Improve structure with explicit working directory management